### PR TITLE
为 osu!mania 模式添加按键数统计与排名系统

### DIFF
--- a/app/const.py
+++ b/app/const.py
@@ -8,3 +8,9 @@ SUPPORT_TOTP_VERIFICATION_VER = 20250913
 # Maximum score in standardised scoring mode
 # https://github.com/ppy/osu/blob/master/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
 MAX_SCORE = 1000000
+
+# Mania key count constants
+# Key count is derived from beatmap Circle Size (CS): int(beatmap.cs)
+MANIA_MIN_KEY_COUNT = 1
+MANIA_MAX_KEY_COUNT = 18
+MANIA_COMMON_KEY_COUNTS = (2, 3, 4, 5, 6, 7, 8, 9, 10)

--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -52,6 +52,12 @@ from .matchmaking import (
     MatchmakingPoolBeatmap,
     MatchmakingUserStats,
 )
+from .mania_key_statistics import (
+    ManiaKeyStatistics,
+    ManiaKeyStatisticsDict,
+    ManiaKeyStatisticsModel,
+    recalculate_mania_key_statistics,
+)
 from .multiplayer_event import MultiplayerEvent, MultiplayerEventResp
 from .notification import Notification, UserNotification
 from .password_reset import PasswordReset
@@ -126,6 +132,9 @@ __all__ = [
     "ItemAttemptsCountModel",
     "LoginSession",
     "LoginSessionResp",
+    "ManiaKeyStatistics",
+    "ManiaKeyStatisticsDict",
+    "ManiaKeyStatisticsModel",
     "MatchmakingPool",
     "MatchmakingPoolBeatmap",
     "MatchmakingUserStats",

--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -47,16 +47,16 @@ from .item_attempts_count import (
     ItemAttemptsCountDict,
     ItemAttemptsCountModel,
 )
-from .matchmaking import (
-    MatchmakingPool,
-    MatchmakingPoolBeatmap,
-    MatchmakingUserStats,
-)
 from .mania_key_statistics import (
     ManiaKeyStatistics,
     ManiaKeyStatisticsDict,
     ManiaKeyStatisticsModel,
     recalculate_mania_key_statistics,
+)
+from .matchmaking import (
+    MatchmakingPool,
+    MatchmakingPoolBeatmap,
+    MatchmakingUserStats,
 )
 from .multiplayer_event import MultiplayerEvent, MultiplayerEventResp
 from .notification import Notification, UserNotification

--- a/app/database/mania_key_statistics.py
+++ b/app/database/mania_key_statistics.py
@@ -135,9 +135,7 @@ class ManiaKeyStatistics(AsyncAttrs, ManiaKeyStatisticsModel, table=True):
     """Database table for user statistics per mania key count."""
 
     __tablename__: str = "lazer_user_mania_key_statistics"
-    __table_args__ = (
-        Index("ix_mania_key_stats_user_key", "user_id", "key_count", unique=True),
-    )
+    __table_args__ = (Index("ix_mania_key_stats_user_key", "user_id", "key_count", unique=True),)
 
     id: int | None = Field(default=None, primary_key=True)
     user_id: int = Field(
@@ -305,9 +303,7 @@ async def recalculate_mania_key_statistics(
     key_stats.level_current = calculate_score_to_level(key_stats.total_score)
 
     # Recalculate PP
-    key_stats.pp, key_stats.hit_accuracy = await calculate_user_pp(
-        session, user_id, gamemode, key_count=key_count
-    )
+    key_stats.pp, key_stats.hit_accuracy = await calculate_user_pp(session, user_id, gamemode, key_count=key_count)
     key_stats.is_ranked = key_stats.pp > 0
 
     await session.commit()

--- a/app/database/mania_key_statistics.py
+++ b/app/database/mania_key_statistics.py
@@ -1,0 +1,373 @@
+"""Mania key-specific user statistics database models.
+
+This module provides models for tracking user statistics broken down
+by mania key count (e.g. 4K, 7K, 10K), derived from the beatmap's
+Circle Size (CS) value rather than mods.
+"""
+
+import math
+from typing import ClassVar, NotRequired, TypedDict
+
+from app.const import MANIA_MAX_KEY_COUNT, MANIA_MIN_KEY_COUNT
+from app.helpers import utcnow
+from app.models.score import GameMode
+
+from ._base import DatabaseModel, included, ondemand
+from .rank_history import RankHistory
+from .user import User, UserDict, UserModel
+
+from pydantic import field_validator
+from sqlalchemy.ext.asyncio import AsyncAttrs
+from sqlalchemy.orm import joinedload
+from sqlmodel import (
+    BigInteger,
+    Column,
+    Field,
+    ForeignKey,
+    Index,
+    Relationship,
+    col,
+    func,
+    select,
+)
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+class ManiaKeyStatisticsDict(TypedDict):
+    """TypedDict representation of mania key statistics."""
+
+    key_count: int
+    count_100: int
+    count_300: int
+    count_50: int
+    count_miss: int
+    pp: float
+    ranked_score: int
+    hit_accuracy: float
+    total_score: int
+    total_hits: int
+    maximum_combo: int
+    play_count: int
+    play_time: int
+    is_ranked: bool
+    level: NotRequired[dict[str, int]]
+    global_rank: NotRequired[int | None]
+    grade_counts: NotRequired[dict[str, int]]
+    country_rank: NotRequired[int | None]
+    user: NotRequired["UserDict"]
+
+
+class ManiaKeyStatisticsModel(DatabaseModel[ManiaKeyStatisticsDict]):
+    """Base model for mania key statistics with transformation support."""
+
+    RANKING_INCLUDES: ClassVar[list[str]] = [
+        "user.country",
+        "user.cover",
+        "user.team",
+    ]
+
+    key_count: int = Field(index=True)
+    count_100: int = Field(default=0, sa_column=Column(BigInteger))
+    count_300: int = Field(default=0, sa_column=Column(BigInteger))
+    count_50: int = Field(default=0, sa_column=Column(BigInteger))
+    count_miss: int = Field(default=0, sa_column=Column(BigInteger))
+
+    pp: float = Field(default=0.0, index=True)
+    ranked_score: int = Field(default=0, sa_column=Column(BigInteger))
+    hit_accuracy: float = Field(default=0.00)
+    total_score: int = Field(default=0, sa_column=Column(BigInteger))
+    total_hits: int = Field(default=0, sa_column=Column(BigInteger))
+    maximum_combo: int = Field(default=0)
+
+    play_count: int = Field(default=0)
+    play_time: int = Field(default=0, sa_column=Column(BigInteger))
+    is_ranked: bool = Field(default=True)
+
+    @field_validator("key_count", mode="before")
+    @classmethod
+    def validate_key_count(cls, v):
+        """Ensure key_count is a positive integer within valid range."""
+        if isinstance(v, float):
+            v = int(v)
+        if isinstance(v, int) and (v < MANIA_MIN_KEY_COUNT or v > MANIA_MAX_KEY_COUNT):
+            raise ValueError(f"key_count must be between {MANIA_MIN_KEY_COUNT} and {MANIA_MAX_KEY_COUNT}")
+        return v
+
+    @included
+    @staticmethod
+    async def level(_session: AsyncSession, statistics: "ManiaKeyStatistics") -> dict[str, int]:
+        return {
+            "current": int(statistics.level_current),
+            "progress": int(math.fmod(statistics.level_current, 1) * 100),
+        }
+
+    @included
+    @staticmethod
+    async def global_rank(session: AsyncSession, statistics: "ManiaKeyStatistics") -> int | None:
+        return await get_mania_key_rank(session, statistics)
+
+    @included
+    @staticmethod
+    async def grade_counts(_session: AsyncSession, statistics: "ManiaKeyStatistics") -> dict[str, int]:
+        return {
+            "ss": statistics.grade_ss,
+            "ssh": statistics.grade_ssh,
+            "s": statistics.grade_s,
+            "sh": statistics.grade_sh,
+            "a": statistics.grade_a,
+        }
+
+    @ondemand
+    @staticmethod
+    async def country_rank(
+        session: AsyncSession, statistics: "ManiaKeyStatistics", user_country: str | None = None
+    ) -> int | None:
+        return await get_mania_key_rank(session, statistics, user_country)
+
+    @ondemand
+    @staticmethod
+    async def user(_session: AsyncSession, statistics: "ManiaKeyStatistics") -> "UserDict":
+        user_instance = await statistics.awaitable_attrs.user
+        return await UserModel.transform(user_instance)
+
+
+class ManiaKeyStatistics(AsyncAttrs, ManiaKeyStatisticsModel, table=True):
+    """Database table for user statistics per mania key count."""
+
+    __tablename__: str = "lazer_user_mania_key_statistics"
+    __table_args__ = (
+        Index("ix_mania_key_stats_user_key", "user_id", "key_count", unique=True),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(
+        default=None,
+        sa_column=Column(
+            BigInteger,
+            ForeignKey("lazer_users.id"),
+            index=True,
+        ),
+    )
+    grade_ss: int = Field(default=0)
+    grade_ssh: int = Field(default=0)
+    grade_s: int = Field(default=0)
+    grade_sh: int = Field(default=0)
+    grade_a: int = Field(default=0)
+
+    level_current: float = Field(default=1)
+
+    user: User = Relationship(back_populates="mania_key_statistics")
+
+
+async def recalculate_mania_key_statistics(
+    session: AsyncSession,
+    user_id: int,
+    key_count: int,
+    gamemode: GameMode,
+) -> None:
+    """Recalculate a user's mania key statistics from scratch.
+
+    This is used when a score is deleted or when data needs to be corrected.
+    It queries all mania scores for this user/key_count combination and
+    rebuilds the statistics record.
+
+    Args:
+        session: Database session.
+        user_id: The user whose statistics to recalculate.
+        key_count: The mania key count (e.g. 4, 7).
+        gamemode: The game mode (should be GameMode.MANIA or a variant).
+    """
+    from app.calculating import calculate_score_to_level
+    from app.config import settings as app_settings
+    from app.database.beatmap import Beatmap
+    from app.database.score import Score, calculate_playtime, calculate_user_pp
+    from app.models.score import Rank
+
+    # Find all mania scores for this user on beatmaps with matching key_count
+    scores = (
+        await session.exec(
+            select(Score)
+            .where(
+                Score.user_id == user_id,
+                Score.gamemode == gamemode,
+            )
+            .join(Beatmap, Score.beatmap_id == Beatmap.id)
+            .where(func.floor(Beatmap.cs) == key_count)
+            .options(joinedload(Score.beatmap))
+        )
+    ).all()
+
+    # Get or create the key statistics record
+    key_stats = (
+        await session.exec(
+            select(ManiaKeyStatistics).where(
+                ManiaKeyStatistics.user_id == user_id,
+                ManiaKeyStatistics.key_count == key_count,
+            )
+        )
+    ).first()
+
+    if key_stats is None:
+        key_stats = ManiaKeyStatistics(
+            user_id=user_id,
+            key_count=key_count,
+        )
+        session.add(key_stats)
+        await session.flush()
+
+    # Reset all counters
+    key_stats.play_count = 0
+    key_stats.total_score = 0
+    key_stats.ranked_score = 0
+    key_stats.maximum_combo = 0
+    key_stats.play_time = 0
+    key_stats.total_hits = 0
+    key_stats.count_100 = 0
+    key_stats.count_300 = 0
+    key_stats.count_50 = 0
+    key_stats.count_miss = 0
+    key_stats.grade_ss = 0
+    key_stats.grade_ssh = 0
+    key_stats.grade_s = 0
+    key_stats.grade_sh = 0
+    key_stats.grade_a = 0
+    key_stats.pp = 0.0
+    key_stats.hit_accuracy = 0.0
+
+    cached_best: dict[int, Score] = {}
+
+    for score in scores:
+        beatmap = score.beatmap
+        if beatmap is None:
+            continue
+
+        ranked = beatmap.beatmap_status.has_pp() | app_settings.enable_all_beatmap_pp
+        display_score = score.get_display_score()
+
+        key_stats.total_score += display_score
+
+        playtime, is_valid = calculate_playtime(score, beatmap.hit_length)
+        if is_valid:
+            key_stats.play_time += playtime
+            key_stats.play_count += 1
+
+        nlarge_tick_miss = score.nlarge_tick_miss or 0
+        nsmall_tick_hit = score.nsmall_tick_hit or 0
+        nlarge_tick_hit = score.nlarge_tick_hit or 0
+
+        key_stats.count_300 += score.n300 + score.ngeki
+        key_stats.count_100 += score.n100 + score.nkatu
+        key_stats.count_50 += score.n50
+        key_stats.count_miss += score.nmiss
+        key_stats.total_hits += (
+            score.n300
+            + score.ngeki
+            + score.n100
+            + score.nkatu
+            + score.n50
+            + nlarge_tick_hit
+            + nlarge_tick_miss
+            + nsmall_tick_hit
+        )
+
+        if ranked and score.passed:
+            key_stats.maximum_combo = max(key_stats.maximum_combo, score.max_combo)
+            previous = cached_best.get(score.beatmap_id)
+            previous_display = previous.get_display_score() if previous else 0
+            difference = display_score - previous_display
+            if difference > 0:
+                cached_best[score.beatmap_id] = score
+                key_stats.ranked_score += difference
+                match score.rank:
+                    case Rank.X:
+                        key_stats.grade_ss += 1
+                    case Rank.XH:
+                        key_stats.grade_ssh += 1
+                    case Rank.S:
+                        key_stats.grade_s += 1
+                    case Rank.SH:
+                        key_stats.grade_sh += 1
+                    case Rank.A:
+                        key_stats.grade_a += 1
+                if previous is not None:
+                    match previous.rank:
+                        case Rank.X:
+                            key_stats.grade_ss -= 1
+                        case Rank.XH:
+                            key_stats.grade_ssh -= 1
+                        case Rank.S:
+                            key_stats.grade_s -= 1
+                        case Rank.SH:
+                            key_stats.grade_sh -= 1
+                        case Rank.A:
+                            key_stats.grade_a -= 1
+
+    key_stats.level_current = calculate_score_to_level(key_stats.total_score)
+
+    # Recalculate PP
+    key_stats.pp, key_stats.hit_accuracy = await calculate_user_pp(
+        session, user_id, gamemode, key_count=key_count
+    )
+    key_stats.is_ranked = key_stats.pp > 0
+
+    await session.commit()
+
+
+async def get_mania_key_rank(
+    session: AsyncSession,
+    statistics: ManiaKeyStatistics,
+    country: str | None = None,
+) -> int | None:
+    """Get the global or country rank for a user's mania key statistics.
+
+    Args:
+        session: Database session.
+        statistics: The mania key statistics record.
+        country: Optional country code to get country rank.
+
+    Returns:
+        The rank, or None if unranked.
+    """
+    query = select(
+        ManiaKeyStatistics.user_id,
+        func.row_number().over(order_by=col(ManiaKeyStatistics.pp).desc()).label("rank"),
+    ).where(
+        ManiaKeyStatistics.key_count == statistics.key_count,
+        ManiaKeyStatistics.pp > 0,
+        col(ManiaKeyStatistics.is_ranked).is_(True),
+    )
+
+    if country is not None:
+        query = query.join(User).where(User.country_code == country)
+
+    subq = query.subquery()
+    result = await session.exec(select(subq.c.rank).where(subq.c.user_id == statistics.user_id))
+
+    rank = result.first()
+    if rank is None:
+        return None
+
+    if country is None:
+        today = utcnow().date()
+        rank_history = (
+            await session.exec(
+                select(RankHistory).where(
+                    RankHistory.user_id == statistics.user_id,
+                    RankHistory.mode == GameMode.MANIA,
+                    RankHistory.key_count == statistics.key_count,
+                    RankHistory.date == today,
+                )
+            )
+        ).first()
+        if rank_history is None:
+            rank_history = RankHistory(
+                user_id=statistics.user_id,
+                mode=GameMode.MANIA,
+                key_count=statistics.key_count,
+                rank=rank,
+                date=today,
+            )
+            session.add(rank_history)
+        else:
+            rank_history.rank = rank
+    return rank

--- a/app/database/rank_history.py
+++ b/app/database/rank_history.py
@@ -38,7 +38,9 @@ class RankHistory(SQLModel, table=True):
     user_id: int = Field(sa_column=Column(BigInteger, ForeignKey("lazer_users.id"), index=True))
     mode: GameMode
     rank: int
-    key_count: int | None = Field(default=None, index=True, description="Mania key count (e.g. 4, 7). Null for non-mania modes.")
+    key_count: int | None = Field(
+        default=None, index=True, description="Mania key count (e.g. 4, 7). Null for non-mania modes."
+    )
     date: dt = Field(
         default_factory=lambda: utcnow().date(),
         sa_column=Column(Date, index=True),
@@ -56,7 +58,9 @@ class RankTop(SQLModel, table=True):
     user_id: int = Field(sa_column=Column(BigInteger, ForeignKey("lazer_users.id"), index=True))
     mode: GameMode
     rank: int
-    key_count: int | None = Field(default=None, index=True, description="Mania key count (e.g. 4, 7). Null for non-mania modes.")
+    key_count: int | None = Field(
+        default=None, index=True, description="Mania key count (e.g. 4, 7). Null for non-mania modes."
+    )
     date: dt = Field(
         default_factory=lambda: utcnow().date(),
         sa_column=Column(Date, index=True),
@@ -83,12 +87,7 @@ class RankHistoryResp(BaseModel):
             wheres.append(RankHistory.key_count == key_count)
 
         results = (
-            await session.exec(
-                select(RankHistory)
-                .where(*wheres)
-                .order_by(col(RankHistory.date).desc())
-                .limit(90)
-            )
+            await session.exec(select(RankHistory).where(*wheres).order_by(col(RankHistory.date).desc()).limit(90))
         ).all()
         data = [result.rank for result in results]
         if len(data) != 90:

--- a/app/database/rank_history.py
+++ b/app/database/rank_history.py
@@ -38,6 +38,7 @@ class RankHistory(SQLModel, table=True):
     user_id: int = Field(sa_column=Column(BigInteger, ForeignKey("lazer_users.id"), index=True))
     mode: GameMode
     rank: int
+    key_count: int | None = Field(default=None, index=True, description="Mania key count (e.g. 4, 7). Null for non-mania modes.")
     date: dt = Field(
         default_factory=lambda: utcnow().date(),
         sa_column=Column(Date, index=True),
@@ -55,6 +56,7 @@ class RankTop(SQLModel, table=True):
     user_id: int = Field(sa_column=Column(BigInteger, ForeignKey("lazer_users.id"), index=True))
     mode: GameMode
     rank: int
+    key_count: int | None = Field(default=None, index=True, description="Mania key count (e.g. 4, 7). Null for non-mania modes.")
     date: dt = Field(
         default_factory=lambda: utcnow().date(),
         sa_column=Column(Date, index=True),
@@ -66,13 +68,24 @@ class RankHistoryResp(BaseModel):
 
     mode: GameMode
     data: list[int]
+    key_count: int | None = None
 
     @classmethod
-    async def from_db(cls, session: AsyncSession, user_id: int, mode: GameMode) -> "RankHistoryResp":
+    async def from_db(
+        cls,
+        session: AsyncSession,
+        user_id: int,
+        mode: GameMode,
+        key_count: int | None = None,
+    ) -> "RankHistoryResp":
+        wheres = [RankHistory.user_id == user_id, RankHistory.mode == mode]
+        if key_count is not None:
+            wheres.append(RankHistory.key_count == key_count)
+
         results = (
             await session.exec(
                 select(RankHistory)
-                .where(RankHistory.user_id == user_id, RankHistory.mode == mode)
+                .where(*wheres)
                 .order_by(col(RankHistory.date).desc())
                 .limit(90)
             )
@@ -81,4 +94,4 @@ class RankHistoryResp(BaseModel):
         if len(data) != 90:
             data.extend([0] * (90 - len(data)))
         data.reverse()
-        return cls(mode=mode, data=data)
+        return cls(mode=mode, data=data, key_count=key_count)

--- a/app/database/score.py
+++ b/app/database/score.py
@@ -21,7 +21,7 @@ from app.calculating import (
     pre_fetch_and_calculate_pp,
 )
 from app.config import settings
-from app.const import NEW_SCORE_FORMAT_VER
+from app.const import MANIA_MAX_KEY_COUNT, MANIA_MIN_KEY_COUNT, NEW_SCORE_FORMAT_VER
 from app.dependencies.database import get_redis
 from app.helpers import utcnow
 from app.log import log
@@ -54,6 +54,7 @@ from .beatmapset import BeatmapsetDict, BeatmapsetModel
 from .best_scores import BestScore
 from .counts import MonthlyPlaycounts
 from .events import Event, EventType
+from .mania_key_statistics import ManiaKeyStatistics
 from .playlist_best_score import PlaylistBestScore
 from .relationship import (
     Relationship as DBRelationship,
@@ -527,6 +528,12 @@ class Score(ScoreModel, table=True):
         session: AsyncSession,
         storage_service: StorageService,
     ):
+        # Capture mania key info before deletion for statistics recalculation
+        gamemode = self.gamemode
+        user_id = self.user_id
+        beatmap = await self.awaitable_attrs.beatmap
+        mania_key_count = int(beatmap.cs) if beatmap and gamemode.is_mania() else None
+
         data = self.to_score_data()
 
         if await self.awaitable_attrs.best_score:
@@ -542,6 +549,12 @@ class Score(ScoreModel, table=True):
 
         await storage_service.delete_file(self.replay_filename)
         await session.delete(self)
+
+        # Recalculate mania key statistics if this was a mania score
+        if mania_key_count is not None and mania_key_count >= MANIA_MIN_KEY_COUNT and mania_key_count <= MANIA_MAX_KEY_COUNT:
+            from .mania_key_statistics import recalculate_mania_key_statistics
+
+            await recalculate_mania_key_statistics(session, user_id, mania_key_count, gamemode)
 
         hub.emit(ScoreDeletedEvent(score=data))
 
@@ -1028,20 +1041,24 @@ async def get_user_best_pp_in_beatmap(
     ).first()
 
 
-async def calculate_user_pp(session: AsyncSession, user_id: int, mode: GameMode) -> tuple[float, float]:
+async def calculate_user_pp(
+    session: AsyncSession, user_id: int, mode: GameMode, key_count: int | None = None
+) -> tuple[float, float]:
     """Calculate the user's total performance points (PP) and accuracy for a specific mode.
 
     Args:
         session: The database session to use for the query.
         user_id: The ID of the user for whom to calculate PP and accuracy.
         mode: The game mode for which to calculate PP and accuracy.
+        key_count: Optional mania key count filter. When provided, only scores
+            on beatmaps with matching CS (Circle Size) are included.
 
     Returns:
         A tuple containing the total PP and accuracy for the user in the specified mode.
     """
     pp_sum = 0
     acc_sum = 0
-    bps = await get_user_best_pp(session, user_id, mode)
+    bps = await get_user_best_pp(session, user_id, mode, key_count=key_count)
     for i, s in enumerate(bps):
         pp_sum += calculate_weighted_pp(s.pp, i)
         acc_sum += calculate_weighted_acc(s.acc, i)
@@ -1057,6 +1074,7 @@ async def get_user_best_pp(
     user: int,
     mode: GameMode,
     limit: int = 1000,
+    key_count: int | None = None,
 ) -> Sequence[BestScore]:
     """Get the user's best scores for a specific mode.
 
@@ -1065,18 +1083,18 @@ async def get_user_best_pp(
         user: The ID of the user for whom to retrieve the best scores.
         mode: The game mode for which to retrieve the best scores.
         limit: The maximum number of scores to return.
+        key_count: Optional mania key count filter. When provided, only scores
+            on beatmaps with matching CS (Circle Size) are included.
 
     Returns:
         A list of the user's best scores for the specified mode, ordered by PP in descending order.
     """
-    return (
-        await session.exec(
-            select(BestScore)
-            .where(BestScore.user_id == user, BestScore.gamemode == mode)
-            .order_by(col(BestScore.pp).desc())
-            .limit(limit)
-        )
-    ).all()
+    query = select(BestScore).where(BestScore.user_id == user, BestScore.gamemode == mode)
+
+    if key_count is not None:
+        query = query.join(Beatmap).where(func.floor(Beatmap.cs) == key_count)
+
+    return (await session.exec(query.order_by(col(BestScore.pp).desc()).limit(limit))).all()
 
 
 def get_play_length(score: "Score", beatmap_length: int):
@@ -1550,6 +1568,26 @@ async def _process_statistics(
     if score.passed and has_pp:
         statistics.pp, statistics.hit_accuracy = await calculate_user_pp(session, statistics.user_id, score.gamemode)
 
+    # Mania key-specific statistics
+    if score.gamemode.is_mania():
+        try:
+            await _process_mania_key_statistics(
+                session=session,
+                user=user,
+                score=score,
+                beatmap_status=beatmap_status,
+                has_pp=has_pp,
+                ranked=ranked,
+                is_valid_playtime=is_valid,
+                playtime=playtime,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to process mania key statistics for user {user_id} score {score_id}",
+                user_id=user.id,
+                score_id=score.id,
+            )
+
     if add_to_db:
         session.add(mouthly_playcount)
         logger.debug(
@@ -1585,6 +1623,152 @@ async def _process_beatmap_playcount(session: AsyncSession, beatmap_id: int, use
             beatmap_id=beatmap_id,
             count=beatmap_playcount.playcount,
         )
+
+
+async def _process_mania_key_statistics(
+    session: AsyncSession,
+    user: User,
+    score: "Score",
+    beatmap_status: BeatmapRankStatus,
+    has_pp: bool,
+    ranked: bool,
+    is_valid_playtime: bool,
+    playtime: int,
+):
+    """Update mania key-specific statistics for a score submission.
+
+    Key count is derived from the beatmap's Circle Size (CS) value.
+    This function queries the best score within the same key_count dimension
+    independently, rather than relying on the global TotalScoreBestScore,
+    because the global best may belong to a different key_count.
+    """
+    beatmap = await score.awaitable_attrs.beatmap
+    if beatmap is None:
+        return
+
+    key_count = int(beatmap.cs)
+    if key_count < MANIA_MIN_KEY_COUNT or key_count > MANIA_MAX_KEY_COUNT:
+        logger.debug(
+            "Skipping mania key statistics for score {score_id}: invalid key_count {key_count}",
+            score_id=score.id,
+            key_count=key_count,
+        )
+        return
+
+    # Get or create key statistics record
+    key_stats = (
+        await session.exec(
+            select(ManiaKeyStatistics).where(
+                ManiaKeyStatistics.user_id == user.id,
+                ManiaKeyStatistics.key_count == key_count,
+            )
+        )
+    ).first()
+
+    if key_stats is None:
+        key_stats = ManiaKeyStatistics(
+            user_id=user.id,
+            key_count=key_count,
+        )
+        session.add(key_stats)
+        await session.flush()
+        logger.debug(
+            "Created mania key statistics for user {user_id} key_count={key_count}",
+            user_id=user.id,
+            key_count=key_count,
+        )
+
+    # Query the user's best score on this beatmap within the same key_count dimension.
+    # We cannot reuse the global `previous_score_best` because it may belong to a
+    # different key_count (e.g. a 7K score on a beatmap that also has a 4K diff).
+    previous_score_best = (
+        await session.exec(
+            select(TotalScoreBestScore)
+            .join(Beatmap, TotalScoreBestScore.beatmap_id == Beatmap.id)
+            .where(
+                TotalScoreBestScore.user_id == user.id,
+                TotalScoreBestScore.beatmap_id == score.beatmap_id,
+                TotalScoreBestScore.gamemode == score.gamemode,
+                func.floor(Beatmap.cs) == key_count,
+            )
+            .order_by(col(TotalScoreBestScore.total_score).desc())
+        )
+    ).first()
+
+    previous_display_score = previous_score_best.score.get_display_score() if previous_score_best else 0
+    previous_score_best_rank = previous_score_best.rank if previous_score_best else None
+
+    # Update score counters (same logic as main statistics)
+    current_display_score = score.get_display_score()
+    difference = current_display_score - previous_display_score
+
+    key_stats.total_score += current_display_score
+
+    # Level is based on total_score, so update it whenever total_score changes
+    key_stats.level_current = calculate_score_to_level(key_stats.total_score)
+
+    if difference > 0 and score.passed and ranked:
+        match score.rank:
+            case Rank.X:
+                key_stats.grade_ss += 1
+            case Rank.XH:
+                key_stats.grade_ssh += 1
+            case Rank.S:
+                key_stats.grade_s += 1
+            case Rank.SH:
+                key_stats.grade_sh += 1
+            case Rank.A:
+                key_stats.grade_a += 1
+        if previous_score_best_rank is not None:
+            match previous_score_best_rank:
+                case Rank.X:
+                    key_stats.grade_ss -= 1
+                case Rank.XH:
+                    key_stats.grade_ssh -= 1
+                case Rank.S:
+                    key_stats.grade_s -= 1
+                case Rank.SH:
+                    key_stats.grade_sh -= 1
+                case Rank.A:
+                    key_stats.grade_a -= 1
+        key_stats.ranked_score += difference
+        key_stats.maximum_combo = max(key_stats.maximum_combo, score.max_combo)
+
+    if is_valid_playtime:
+        key_stats.play_count += 1
+        key_stats.play_time += playtime
+
+    nlarge_tick_miss = score.nlarge_tick_miss or 0
+    nsmall_tick_hit = score.nsmall_tick_hit or 0
+    nlarge_tick_hit = score.nlarge_tick_hit or 0
+
+    key_stats.count_100 += score.n100 + score.nkatu
+    key_stats.count_300 += score.n300 + score.ngeki
+    key_stats.count_50 += score.n50
+    key_stats.count_miss += score.nmiss
+    key_stats.total_hits += (
+        score.n300
+        + score.n100
+        + score.n50
+        + score.ngeki
+        + score.nkatu
+        + nlarge_tick_hit
+        + nlarge_tick_miss
+        + nsmall_tick_hit
+    )
+
+    if score.passed and has_pp:
+        key_stats.pp, key_stats.hit_accuracy = await calculate_user_pp(
+            session, key_stats.user_id, score.gamemode, key_count=key_count
+        )
+        key_stats.is_ranked = key_stats.pp > 0
+
+    logger.debug(
+        "Updated mania key statistics for user {user_id} key_count={key_count} pp={pp}",
+        user_id=user.id,
+        key_count=key_count,
+        pp=key_stats.pp,
+    )
 
 
 async def process_user(

--- a/app/database/score.py
+++ b/app/database/score.py
@@ -551,7 +551,11 @@ class Score(ScoreModel, table=True):
         await session.delete(self)
 
         # Recalculate mania key statistics if this was a mania score
-        if mania_key_count is not None and mania_key_count >= MANIA_MIN_KEY_COUNT and mania_key_count <= MANIA_MAX_KEY_COUNT:
+        if (
+            mania_key_count is not None
+            and mania_key_count >= MANIA_MIN_KEY_COUNT
+            and mania_key_count <= MANIA_MAX_KEY_COUNT
+        ):
             from .mania_key_statistics import recalculate_mania_key_statistics
 
             await recalculate_mania_key_statistics(session, user_id, mania_key_count, gamemode)

--- a/app/database/user.py
+++ b/app/database/user.py
@@ -22,6 +22,7 @@ from .beatmap_playcounts import BeatmapPlaycounts
 from .counts import CountResp, MonthlyPlaycounts, ReplayWatchedCount
 from .daily_challenge import DailyChallengeStats, DailyChallengeStatsResp
 from .events import Event
+from .mania_key_statistics import ManiaKeyStatistics, ManiaKeyStatisticsDict
 from .notification import Notification, UserNotification
 from .rank_history import RankHistory, RankHistoryResp, RankTop
 from .relationship import RelationshipModel
@@ -173,6 +174,7 @@ class UserDict(TypedDict):
     default_group: NotRequired[str]
     session_verified: NotRequired[bool]
     session_verification_method: NotRequired[Literal["totp", "mail"] | None]
+    mania_key_statistics: NotRequired[list["ManiaKeyStatisticsDict"]]
 
 
 class UserModel(DatabaseModel[UserDict]):
@@ -273,6 +275,7 @@ class UserModel(DatabaseModel[UserDict]):
         "statistics.variants",
         "team",
         "user_achievements",
+        "mania_key_statistics",
         *PROFILE_HEADER_INCLUDES,
         *USER_TRANSFORMER_INCLUDES,
     ]
@@ -712,6 +715,21 @@ class UserModel(DatabaseModel[UserDict]):
             return await LoginSessionService.get_login_method(obj.id, token_id, redis)
         return None
 
+    @ondemand
+    @staticmethod
+    async def mania_key_statistics(
+        _session: AsyncSession,
+        obj: "User",
+    ) -> list["ManiaKeyStatisticsDict"]:
+        from .mania_key_statistics import ManiaKeyStatisticsModel
+
+        stats = await obj.awaitable_attrs.mania_key_statistics
+        return [
+            await ManiaKeyStatisticsModel.transform(s)
+            for s in stats
+            if s.pp > 0 and s.is_ranked
+        ]
+
 
 class User(AsyncAttrs, UserModel, table=True):
     __tablename__: str = "lazer_users"
@@ -737,6 +755,9 @@ class User(AsyncAttrs, UserModel, table=True):
     events: Mapped[list[Event]] = Relationship(back_populates="user")
     totp_key: Mapped[TotpKeys | None] = Relationship(back_populates="user")
     user_preference: Mapped[UserPreference | None] = Relationship(back_populates="user")
+    mania_key_statistics: Mapped[list[ManiaKeyStatistics]] = Relationship(
+        back_populates="user",
+    )
 
     async def is_user_can_pm(self, from_user: "User", session: AsyncSession) -> tuple[bool, str]:
         """Check if the user can receive private messages from the given user.

--- a/app/database/user.py
+++ b/app/database/user.py
@@ -724,11 +724,7 @@ class UserModel(DatabaseModel[UserDict]):
         from .mania_key_statistics import ManiaKeyStatisticsModel
 
         stats = await obj.awaitable_attrs.mania_key_statistics
-        return [
-            await ManiaKeyStatisticsModel.transform(s)
-            for s in stats
-            if s.pp > 0 and s.is_ranked
-        ]
+        return [await ManiaKeyStatisticsModel.transform(s) for s in stats if s.pp > 0 and s.is_ranked]
 
 
 class User(AsyncAttrs, UserModel, table=True):

--- a/app/models/score.py
+++ b/app/models/score.py
@@ -130,6 +130,10 @@ class GameMode(StrEnum):
     def is_custom_ruleset(self) -> bool:
         return not self.is_official()
 
+    def is_mania(self) -> bool:
+        """Check if this game mode is mania (including potential future variants like mania RX)."""
+        return self == GameMode.MANIA or int(self) == 3
+
     def to_base_ruleset(self) -> "GameMode":
         gamemode = {
             GameMode.OSURX: GameMode.OSU,

--- a/app/router/notification/banchobot.py
+++ b/app/router/notification/banchobot.py
@@ -337,7 +337,7 @@ async def _score(
 Played at {score.started_at}
 {score.pp:.2f}pp {bp_pp} {score.accuracy:.2%} {",".join(mod_to_save(score.mods))} {score.rank.name.upper()}
 Great: {score.n300}, Good: {score.n100}, Meh: {score.n50}, Miss: {score.nmiss}"""
-    if score.gamemode == GameMode.MANIA:
+    if score.gamemode.is_mania():
         keys = next((mod["acronym"] for mod in score.mods if mod["acronym"].endswith("K")), None)
         if keys is None:
             keys = f"{int(score.beatmap.cs)}K"

--- a/app/router/private/__init__.py
+++ b/app/router/private/__init__.py
@@ -14,6 +14,7 @@ from . import (  # noqa: F401
     beatmapset,
     cover,
     gamemodes,
+    mania_key,
     oauth,
     password,
     relationship,

--- a/app/router/private/mania_key.py
+++ b/app/router/private/mania_key.py
@@ -21,7 +21,6 @@ from fastapi import BackgroundTasks, Path, Query, Security
 from pydantic import BaseModel, Field
 from sqlmodel import col, func, select
 
-
 SortType = Literal["performance", "score"]
 
 
@@ -100,9 +99,13 @@ async def get_mania_key_ranking(
         include.append("country_rank")
 
     # Query total count
-    count_query = select(func.count()).select_from(ManiaKeyStatistics).where(
-        *wheres,
-        ~User.is_restricted_query(col(ManiaKeyStatistics.user_id)),
+    count_query = (
+        select(func.count())
+        .select_from(ManiaKeyStatistics)
+        .where(
+            *wheres,
+            ~User.is_restricted_query(col(ManiaKeyStatistics.user_id)),
+        )
     )
     total_count_result = await session.exec(count_query)
     total_count = total_count_result.one()
@@ -158,8 +161,7 @@ async def get_mania_key_ranking(
 @router.get(
     "/rankings/mania/user/{user_id}",
     name="Get user mania key statistics",
-    description="Get a user's mania mode statistics broken down by key count. "
-    "This is a g0v0 extension API.",
+    description="Get a user's mania mode statistics broken down by key count. This is a g0v0 extension API.",
     tags=["Rankings"],
 )
 async def get_user_mania_key_stats(

--- a/app/router/private/mania_key.py
+++ b/app/router/private/mania_key.py
@@ -1,0 +1,202 @@
+"""Mania key-specific ranking API endpoints.
+
+This module provides g0v0 extension endpoints for retrieving mania rankings
+broken down by key count (derived from beatmap CS value).
+"""
+
+from typing import Annotated, Literal
+
+from app.config import settings
+from app.database import ManiaKeyStatistics, User
+from app.database.mania_key_statistics import ManiaKeyStatisticsDict, ManiaKeyStatisticsModel
+from app.dependencies.database import Database, get_redis
+from app.dependencies.user import get_current_user
+from app.helpers import api_doc
+from app.models.error import ErrorType, RequestError
+from app.service.ranking_cache_service import get_ranking_cache_service
+
+from .router import router
+
+from fastapi import BackgroundTasks, Path, Query, Security
+from pydantic import BaseModel, Field
+from sqlmodel import col, func, select
+
+
+SortType = Literal["performance", "score"]
+
+
+class ManiaKeyRankingResponse(BaseModel):
+    """Response model for mania key rankings."""
+
+    ranking: list[ManiaKeyStatisticsDict]
+    total: int = Field(0, description="Total number of users")
+
+
+class UserManiaKeyStatsResponse(BaseModel):
+    """Response model for user's mania key statistics across all key counts."""
+
+    user_id: int
+    username: str
+    statistics: list[ManiaKeyStatisticsDict]
+
+
+@router.get(
+    "/rankings/mania/{key_count}/{sort}",
+    responses={
+        200: api_doc(
+            "Mania key-specific rankings",
+            {"ranking": list[ManiaKeyStatisticsModel], "total": int},
+            ["user.country", "user.cover"],
+            name="ManiaKeyRankingResponse",
+        )
+    },
+    name="Get mania key-specific rankings",
+    description="Get user rankings for mania mode filtered by key count (derived from beatmap CS). "
+    "This is a g0v0 extension API.",
+    tags=["Rankings"],
+)
+async def get_mania_key_ranking(
+    session: Database,
+    background_tasks: BackgroundTasks,
+    key_count: Annotated[int, Path(ge=1, le=18, description="Key count (e.g. 4 for 4K, 7 for 7K)")],
+    sort: Annotated[SortType, Path(..., description="Ranking type: performance (pp) / score (ranked score)")],
+    current_user: Annotated[User, Security(get_current_user, scopes=["public"])],
+    country: Annotated[str | None, Query(description="Country code")] = None,
+    page: Annotated[int, Query(ge=1, description="Page number")] = 1,
+):
+    """Get mania key-specific rankings.
+
+    Key count is derived from the beatmap's Circle Size (CS) value.
+    For example, a beatmap with CS=4 is a 4K map, CS=7 is a 7K map.
+    """
+    redis = get_redis()
+    cache_service = get_ranking_cache_service(redis)
+
+    # Try to get data from cache
+    cached_data = await cache_service.get_cached_mania_key_ranking(key_count, sort, country, page)
+    cached_stats = await cache_service.get_cached_mania_key_stats(key_count, sort, country)
+
+    if cached_data and cached_stats:
+        return {
+            "ranking": cached_data,
+            "total": cached_stats.get("total", 0),
+        }
+
+    # Cache miss, query from database
+    wheres = [
+        col(ManiaKeyStatistics.key_count) == key_count,
+        col(ManiaKeyStatistics.pp) > 0,
+        col(ManiaKeyStatistics.is_ranked).is_(True),
+    ]
+    include = ManiaKeyStatistics.RANKING_INCLUDES.copy()
+
+    if sort == "performance":
+        order_by = col(ManiaKeyStatistics.pp).desc()
+    else:
+        order_by = col(ManiaKeyStatistics.ranked_score).desc()
+
+    if country:
+        wheres.append(col(ManiaKeyStatistics.user).has(country_code=country.upper()))
+        include.append("country_rank")
+
+    # Query total count
+    count_query = select(func.count()).select_from(ManiaKeyStatistics).where(
+        *wheres,
+        ~User.is_restricted_query(col(ManiaKeyStatistics.user_id)),
+    )
+    total_count_result = await session.exec(count_query)
+    total_count = total_count_result.one()
+
+    statistics_list = await session.exec(
+        select(ManiaKeyStatistics)
+        .where(
+            *wheres,
+            ~User.is_restricted_query(col(ManiaKeyStatistics.user_id)),
+        )
+        .order_by(order_by)
+        .limit(50)
+        .offset(50 * (page - 1))
+    )
+
+    # Transform to response format
+    ranking_data = []
+    for statistics in statistics_list:
+        user_stats_resp = await ManiaKeyStatisticsModel.transform(
+            statistics, includes=include, user_country=current_user.country_code
+        )
+        ranking_data.append(user_stats_resp)
+
+    # Async cache data
+    cache_data = ranking_data
+    stats_data = {"total": total_count}
+
+    background_tasks.add_task(
+        cache_service.cache_mania_key_ranking,
+        key_count,
+        sort,
+        cache_data,
+        country,
+        page,
+        ttl=settings.ranking_cache_expire_minutes * 60,
+    )
+
+    background_tasks.add_task(
+        cache_service.cache_mania_key_stats,
+        key_count,
+        sort,
+        stats_data,
+        country,
+        ttl=settings.ranking_cache_expire_minutes * 60,
+    )
+
+    return {
+        "ranking": ranking_data,
+        "total": total_count,
+    }
+
+
+@router.get(
+    "/rankings/mania/user/{user_id}",
+    name="Get user mania key statistics",
+    description="Get a user's mania mode statistics broken down by key count. "
+    "This is a g0v0 extension API.",
+    tags=["Rankings"],
+)
+async def get_user_mania_key_stats(
+    session: Database,
+    current_user: Annotated[User, Security(get_current_user, scopes=["public"])],
+    user_id: Annotated[int, Path(description="User ID to query")],
+):
+    """Get a user's mania key-specific statistics across all key counts.
+
+    Returns all ranked ManiaKeyStatistics records for the given user,
+    sorted by key count ascending.
+    """
+    target_user = (await session.exec(select(User).where(User.id == user_id))).first()
+    if not target_user:
+        raise RequestError(ErrorType.USER_NOT_FOUND, "The requested user could not be found.")
+
+    stats = (
+        await session.exec(
+            select(ManiaKeyStatistics)
+            .where(
+                ManiaKeyStatistics.user_id == user_id,
+                ManiaKeyStatistics.pp > 0,
+                col(ManiaKeyStatistics.is_ranked).is_(True),
+            )
+            .order_by(col(ManiaKeyStatistics.key_count))
+        )
+    ).all()
+
+    statistics_data: list[ManiaKeyStatisticsDict] = []
+    for stat in stats:
+        resp = await ManiaKeyStatisticsModel.transform(stat, includes=[])
+        # Remove nested user object to keep response compact
+        resp.pop("user", None)
+        statistics_data.append(resp)  # type: ignore[arg-type]
+
+    return UserManiaKeyStatsResponse(
+        user_id=user_id,
+        username=target_user.username,
+        statistics=statistics_data,
+    )

--- a/app/router/private/router.py
+++ b/app/router/private/router.py
@@ -11,5 +11,7 @@ router = APIRouter(prefix="/api/private", dependencies=LIMITERS)
 
 # Import and include sub-routers
 from .audio_proxy import router as audio_proxy_router
+from .mania_key import router as mania_key_router
 
 router.include_router(audio_proxy_router)
+router.include_router(mania_key_router)

--- a/app/router/v2/ranking.py
+++ b/app/router/v2/ranking.py
@@ -523,6 +523,3 @@ async def get_user_ranking(
         "ranking": ranking_data,
         "total": total_count,
     }
-
-
-

--- a/app/router/v2/ranking.py
+++ b/app/router/v2/ranking.py
@@ -523,3 +523,6 @@ async def get_user_ranking(
         "ranking": ranking_data,
         "total": total_count,
     }
+
+
+

--- a/app/service/ranking_cache_service.py
+++ b/app/service/ranking_cache_service.py
@@ -656,7 +656,10 @@ class RankingCacheService:
                             break
                     scores = (
                         await session.exec(
-                            select(Score).where(*wheres, col(Score.pp) <= cursor).order_by(col(Score.pp).desc()).limit(50)
+                            select(Score)
+                            .where(*wheres, col(Score.pp) <= cursor)
+                            .order_by(col(Score.pp).desc())
+                            .limit(50)
                         )
                     ).all()
                     data = [
@@ -789,8 +792,6 @@ class RankingCacheService:
 
         # Get list of countries to cache (top 20 countries by active user count)
         from app.database import User
-
-        from sqlmodel import func
 
         countries_query = (
             await session.exec(

--- a/app/service/ranking_cache_service.py
+++ b/app/service/ranking_cache_service.py
@@ -9,14 +9,16 @@ import sys
 from typing import TYPE_CHECKING, Literal
 
 from app.config import settings
-from app.const import NEW_SCORE_FORMAT_VER
+from app.const import MANIA_COMMON_KEY_COUNTS, NEW_SCORE_FORMAT_VER
+from app.database import ManiaKeyStatistics, User
+from app.database.mania_key_statistics import ManiaKeyStatisticsModel
 from app.database.statistics import UserStatistics, UserStatisticsModel
 from app.helpers import replace_asset_urls, safe_json_dumps, utcnow
 from app.log import logger
 from app.models.score import GameMode
 
 from redis.asyncio import Redis
-from sqlmodel import col, select
+from sqlmodel import col, func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 if TYPE_CHECKING:
@@ -32,8 +34,23 @@ class RankingCacheService:
 
     def __init__(self, redis: Redis):
         self.redis = redis
-        self._refreshing = False
+        self._refresh_locks: dict[str, asyncio.Lock] = {}
         self._background_tasks: set = set()
+
+    def _get_refresh_lock(self, lock_key: str) -> asyncio.Lock:
+        """Get or create an async lock for a specific refresh type.
+
+        This allows different ranking types to refresh concurrently while
+        preventing duplicate refreshes of the same type.
+        """
+        if lock_key not in self._refresh_locks:
+            self._refresh_locks[lock_key] = asyncio.Lock()
+        return self._refresh_locks[lock_key]
+
+    @property
+    def is_any_refreshing(self) -> bool:
+        """Check if any refresh operation is currently in progress."""
+        return any(lock.locked() for lock in self._refresh_locks.values())
 
     def _get_cache_key(
         self,
@@ -71,6 +88,27 @@ class RankingCacheService:
     def _get_team_stats_cache_key(self, ruleset: GameMode) -> str:
         """Generate team ranking statistics cache key."""
         return f"team_ranking:stats:{ruleset}"
+
+    def _get_mania_key_cache_key(
+        self,
+        key_count: int,
+        type: Literal["performance", "score"],
+        country: str | None = None,
+        page: int = 1,
+    ) -> str:
+        """Generate mania key ranking cache key."""
+        country_part = f":{country.upper()}" if country else ""
+        return f"mania_key_ranking:{key_count}:{type}{country_part}:page:{page}"
+
+    def _get_mania_key_stats_cache_key(
+        self,
+        key_count: int,
+        type: Literal["performance", "score"],
+        country: str | None = None,
+    ) -> str:
+        """Generate mania key ranking statistics cache key."""
+        country_part = f":{country.upper()}" if country else ""
+        return f"mania_key_ranking:stats:{key_count}:{type}{country_part}"
 
     async def get_cached_ranking(
         self,
@@ -245,6 +283,80 @@ class RankingCacheService:
         except Exception as e:
             logger.error(f"Error caching team stats: {e}")
 
+    async def get_cached_mania_key_ranking(
+        self,
+        key_count: int,
+        type: Literal["performance", "score"],
+        country: str | None = None,
+        page: int = 1,
+    ) -> list[dict] | None:
+        """Get cached mania key ranking data."""
+        try:
+            cache_key = self._get_mania_key_cache_key(key_count, type, country, page)
+            cached_data = await self.redis.get(cache_key)
+
+            if cached_data:
+                return json.loads(cached_data)
+            return None
+        except Exception as e:
+            logger.error(f"Error getting cached mania key ranking: {e}")
+            return None
+
+    async def cache_mania_key_ranking(
+        self,
+        key_count: int,
+        type: Literal["performance", "score"],
+        ranking_data: list[dict],
+        country: str | None = None,
+        page: int = 1,
+        ttl: int | None = None,
+    ) -> None:
+        """Cache mania key ranking data."""
+        try:
+            cache_key = self._get_mania_key_cache_key(key_count, type, country, page)
+            if ttl is None:
+                ttl = settings.ranking_cache_expire_minutes * 60
+            await self.redis.set(cache_key, safe_json_dumps(ranking_data), ex=ttl)
+            logger.debug(f"Cached mania key ranking data for {cache_key}")
+        except Exception as e:
+            logger.error(f"Error caching mania key ranking: {e}")
+
+    async def get_cached_mania_key_stats(
+        self,
+        key_count: int,
+        type: Literal["performance", "score"],
+        country: str | None = None,
+    ) -> dict | None:
+        """Get cached mania key ranking statistics."""
+        try:
+            cache_key = self._get_mania_key_stats_cache_key(key_count, type, country)
+            cached_data = await self.redis.get(cache_key)
+
+            if cached_data:
+                return json.loads(cached_data)
+            return None
+        except Exception as e:
+            logger.error(f"Error getting cached mania key stats: {e}")
+            return None
+
+    async def cache_mania_key_stats(
+        self,
+        key_count: int,
+        type: Literal["performance", "score"],
+        stats: dict,
+        country: str | None = None,
+        ttl: int | None = None,
+    ) -> None:
+        """Cache mania key ranking statistics."""
+        try:
+            cache_key = self._get_mania_key_stats_cache_key(key_count, type, country)
+            if ttl is None:
+                ttl = settings.ranking_cache_expire_minutes * 60 * 6
+            await self.redis.set(cache_key, safe_json_dumps(stats), ex=ttl)
+            logger.debug(f"Cached mania key stats for {cache_key}")
+        except Exception as e:
+            logger.error(f"Error caching mania key stats: {e}")
+
     async def get_cached_country_stats(self, ruleset: GameMode) -> dict | None:
         """Get cached country ranking statistics."""
         try:
@@ -306,96 +418,99 @@ class RankingCacheService:
         max_pages: int | None = None,  # Allow None to use config default
     ) -> None:
         """Refresh ranking cache."""
-        if self._refreshing:
-            logger.debug(f"Ranking cache refresh already in progress for {ruleset}:{type}")
+        country_part = f":{country}" if country else ""
+        lock_key = f"ranking:{ruleset}:{type}{country_part}"
+        lock = self._get_refresh_lock(lock_key)
+
+        # Skip if already refreshing this specific ranking
+        if lock.locked():
+            logger.debug(f"Ranking cache refresh already in progress for {ruleset}:{type}{country_part}")
             return
 
-        # Use config file settings
-        if max_pages is None:
-            max_pages = settings.ranking_cache_max_pages
+        async with lock:
+            # Use config file settings
+            if max_pages is None:
+                max_pages = settings.ranking_cache_max_pages
 
-        self._refreshing = True
-        try:
-            logger.info(f"Starting ranking cache refresh for {ruleset}:{type}")
+            try:
+                logger.info(f"Starting ranking cache refresh for {ruleset}:{type}{country_part}")
 
-            # Build query conditions
-            wheres = [
-                col(UserStatistics.mode) == ruleset,
-                col(UserStatistics.pp) > 0,
-                col(UserStatistics.is_ranked).is_(True),
-            ]
-            include = UserStatistics.RANKING_INCLUDES.copy()
+                # Build query conditions
+                wheres = [
+                    col(UserStatistics.mode) == ruleset,
+                    col(UserStatistics.pp) > 0,
+                    col(UserStatistics.is_ranked).is_(True),
+                ]
+                include = UserStatistics.RANKING_INCLUDES.copy()
 
-            if type == "performance":
-                order_by = col(UserStatistics.pp).desc()
-                include.append("rank_change_since_30_days")
-            else:
-                order_by = col(UserStatistics.ranked_score).desc()
+                if type == "performance":
+                    order_by = col(UserStatistics.pp).desc()
+                    include.append("rank_change_since_30_days")
+                else:
+                    order_by = col(UserStatistics.ranked_score).desc()
 
-            if country:
-                wheres.append(col(UserStatistics.user).has(country_code=country.upper()))
-                include.append("country_rank")
+                if country:
+                    wheres.append(col(UserStatistics.user).has(country_code=country.upper()))
+                    include.append("country_rank")
 
-            # Get total user count for statistics
-            total_users_query = select(UserStatistics).where(*wheres)
-            total_users = len((await session.exec(total_users_query)).all())
+                # Get total user count for statistics
+                total_users_query = select(UserStatistics).where(*wheres)
+                total_users = len((await session.exec(total_users_query)).all())
 
-            # Calculate statistics
-            stats = {
-                "total": total_users,
-                "total_users": total_users,
-                "last_updated": utcnow().isoformat(),
-                "type": type,
-                "ruleset": ruleset,
-                "country": country,
-            }
+                # Calculate statistics
+                stats = {
+                    "total": total_users,
+                    "total_users": total_users,
+                    "last_updated": utcnow().isoformat(),
+                    "type": type,
+                    "ruleset": ruleset,
+                    "country": country,
+                }
 
-            # Cache statistics
-            await self.cache_stats(ruleset, type, stats, country)
+                # Cache statistics
+                await self.cache_stats(ruleset, type, stats, country)
 
-            # Paginated data caching
-            for page in range(1, max_pages + 1):
-                try:
-                    statistics_list = await session.exec(
-                        select(UserStatistics).where(*wheres).order_by(order_by).limit(50).offset(50 * (page - 1))
-                    )
+                # Paginated data caching
+                for page in range(1, max_pages + 1):
+                    try:
+                        statistics_list = await session.exec(
+                            select(UserStatistics).where(*wheres).order_by(order_by).limit(50).offset(50 * (page - 1))
+                        )
 
-                    statistics_data = statistics_list.all()
-                    if not statistics_data:
-                        break  # No more data
+                        statistics_data = statistics_list.all()
+                        if not statistics_data:
+                            break  # No more data
 
-                    # Convert to response format and ensure proper serialization
-                    ranking_data = []
-                    for statistics in statistics_data:
-                        user_stats_resp = await UserStatisticsModel.transform(statistics, includes=include)
+                        # Convert to response format and ensure proper serialization
+                        ranking_data = []
+                        for statistics in statistics_data:
+                            user_stats_resp = await UserStatisticsModel.transform(statistics, includes=include)
 
-                        user_dict = user_stats_resp
+                            user_dict = user_stats_resp
 
-                        # Apply resource proxy processing
-                        if settings.enable_asset_proxy:
-                            try:
-                                user_dict = await replace_asset_urls(user_dict)
-                            except Exception as e:
-                                logger.warning(f"Asset proxy processing failed for ranking cache: {e}")
+                            # Apply resource proxy processing
+                            if settings.enable_asset_proxy:
+                                try:
+                                    user_dict = await replace_asset_urls(user_dict)
+                                except Exception as e:
+                                    logger.warning(f"Asset proxy processing failed for ranking cache: {e}")
 
-                        ranking_data.append(user_dict)
+                            ranking_data.append(user_dict)
 
-                    # Cache this page's data
-                    await self.cache_ranking(ruleset, type, ranking_data, country, page)
+                        # Cache this page's data
+                        await self.cache_ranking(ruleset, type, ranking_data, country, page)
 
-                    # Add delay to avoid database overload
-                    if page < max_pages:
-                        await asyncio.sleep(0.1)
+                        # Add delay to avoid database overload
+                        if page < max_pages:
+                            await asyncio.sleep(0.1)
 
-                except Exception as e:
-                    logger.error(f"Error caching page {page} for {ruleset}:{type}: {e}")
+                    except Exception as e:
+                        logger.error(f"Error caching page {page} for {ruleset}:{type}: {e}")
 
-            logger.debug(f"Completed ranking cache refresh for {ruleset}:{type}")
+                logger.debug(f"Completed ranking cache refresh for {ruleset}:{type}{country_part}")
 
-        except Exception as e:
-            logger.error(f"Ranking cache refresh failed for {ruleset}:{type}: {e}")
-        finally:
-            self._refreshing = False
+            except Exception as e:
+                logger.error(f"Ranking cache refresh failed for {ruleset}:{type}{country_part}: {e}")
 
     async def refresh_country_ranking_cache(
         self,
@@ -404,96 +519,98 @@ class RankingCacheService:
         max_pages: int | None = None,
     ) -> None:
         """Refresh country ranking cache."""
-        if self._refreshing:
+        lock_key = f"country:{ruleset}"
+        lock = self._get_refresh_lock(lock_key)
+
+        # Skip if already refreshing this specific country ranking
+        if lock.locked():
             logger.debug(f"Country ranking cache refresh already in progress for {ruleset}")
             return
 
-        if max_pages is None:
-            max_pages = settings.ranking_cache_max_pages
+        async with lock:
+            if max_pages is None:
+                max_pages = settings.ranking_cache_max_pages
 
-        self._refreshing = True
-        try:
-            logger.info(f"Starting country ranking cache refresh for {ruleset}")
+            try:
+                logger.info(f"Starting country ranking cache refresh for {ruleset}")
 
-            # Get all countries
-            from app.database import User
+                # Get all countries
+                from app.database import User
 
-            countries = (await session.exec(select(User.country_code).distinct())).all()
+                countries = (await session.exec(select(User.country_code).distinct())).all()
 
-            # Calculate statistics for each country
-            country_stats_list = []
-            for country in countries:
-                if not country:  # Skip empty country codes
-                    continue
+                # Calculate statistics for each country
+                country_stats_list = []
+                for country in countries:
+                    if not country:  # Skip empty country codes
+                        continue
 
-                statistics = (
-                    await session.exec(
-                        select(UserStatistics).where(
-                            UserStatistics.mode == ruleset,
-                            UserStatistics.pp > 0,
-                            col(UserStatistics.user).has(country_code=country),
-                            col(UserStatistics.user).has(is_active=True),
+                    statistics = (
+                        await session.exec(
+                            select(UserStatistics).where(
+                                UserStatistics.mode == ruleset,
+                                UserStatistics.pp > 0,
+                                col(UserStatistics.user).has(country_code=country),
+                                col(UserStatistics.user).has(is_active=True),
+                            )
                         )
-                    )
-                ).all()
+                    ).all()
 
-                if not statistics:  # Skip countries with no data
-                    continue
+                    if not statistics:  # Skip countries with no data
+                        continue
 
-                pp = 0
-                country_stats = {
-                    "code": country,
-                    "active_users": 0,
-                    "play_count": 0,
-                    "ranked_score": 0,
-                    "performance": 0,
+                    pp = 0
+                    country_stats = {
+                        "code": country,
+                        "active_users": 0,
+                        "play_count": 0,
+                        "ranked_score": 0,
+                        "performance": 0,
+                    }
+
+                    for stat in statistics:
+                        country_stats["active_users"] += 1
+                        country_stats["play_count"] += stat.play_count
+                        country_stats["ranked_score"] += stat.ranked_score
+                        pp += stat.pp
+
+                    country_stats["performance"] = round(pp)
+                    country_stats_list.append(country_stats)
+
+                # Sort by performance
+                country_stats_list.sort(key=lambda x: x["performance"], reverse=True)
+
+                # Calculate statistics
+                stats = {
+                    "total_countries": len(country_stats_list),
+                    "last_updated": utcnow().isoformat(),
+                    "ruleset": ruleset,
                 }
 
-                for stat in statistics:
-                    country_stats["active_users"] += 1
-                    country_stats["play_count"] += stat.play_count
-                    country_stats["ranked_score"] += stat.ranked_score
-                    pp += stat.pp
+                # Cache statistics
+                await self.cache_country_stats(ruleset, stats)
 
-                country_stats["performance"] = round(pp)
-                country_stats_list.append(country_stats)
+                # Paginated data caching (50 countries per page)
+                page_size = 50
+                for page in range(1, max_pages + 1):
+                    start_idx = (page - 1) * page_size
+                    end_idx = start_idx + page_size
 
-            # Sort by performance
-            country_stats_list.sort(key=lambda x: x["performance"], reverse=True)
+                    page_data = country_stats_list[start_idx:end_idx]
+                    if not page_data:
+                        break  # No more data
 
-            # Calculate statistics
-            stats = {
-                "total_countries": len(country_stats_list),
-                "last_updated": utcnow().isoformat(),
-                "ruleset": ruleset,
-            }
+                    # Cache this page's data
+                    await self.cache_country_ranking(ruleset, page_data, page)
 
-            # Cache statistics
-            await self.cache_country_stats(ruleset, stats)
+                    # Add delay to avoid Redis overload
+                    if page < max_pages and page_data:
+                        await asyncio.sleep(0.1)
 
-            # Paginated data caching (50 countries per page)
-            page_size = 50
-            for page in range(1, max_pages + 1):
-                start_idx = (page - 1) * page_size
-                end_idx = start_idx + page_size
+                logger.info(f"Completed country ranking cache refresh for {ruleset}")
 
-                page_data = country_stats_list[start_idx:end_idx]
-                if not page_data:
-                    break  # No more data
-
-                # Cache this page's data
-                await self.cache_country_ranking(ruleset, page_data, page)
-
-                # Add delay to avoid Redis overload
-                if page < max_pages and page_data:
-                    await asyncio.sleep(0.1)
-
-            logger.info(f"Completed country ranking cache refresh for {ruleset}")
-
-        except Exception as e:
-            logger.error(f"Country ranking cache refresh failed for {ruleset}: {e}")
-        finally:
-            self._refreshing = False
+            except Exception as e:
+                logger.error(f"Country ranking cache refresh failed for {ruleset}: {e}")
 
     async def refresh_top_scores_cache(
         self, session: AsyncSession, ruleset: GameMode, max_pages: int | None = None
@@ -506,54 +623,164 @@ class RankingCacheService:
             col(Score.id).in_(select(BestScore.score_id).where(BestScore.gamemode == ruleset)),
         ]
 
-        if self._refreshing:
+        lock_key = f"top_scores:{ruleset}"
+        lock = self._get_refresh_lock(lock_key)
+
+        # Skip if already refreshing this specific top scores cache
+        if lock.locked():
             logger.debug(f"Top scores cache refresh already in progress for {ruleset}")
             return
 
-        if max_pages is None:
-            max_pages = settings.top_score_cache_max_pages
+        async with lock:
+            if max_pages is None:
+                max_pages = settings.top_score_cache_max_pages
 
-        self._refreshing = True
-        try:
-            logger.info(f"Starting top scores cache refresh for {ruleset}")
+            try:
+                logger.info(f"Starting top scores cache refresh for {ruleset}")
 
-            # Get top scores
-            for page in range(1, max_pages + 1):
-                if page == 1:
-                    cursor = sys.maxsize
-                else:
-                    cursor = (
+                # Get top scores
+                for page in range(1, max_pages + 1):
+                    if page == 1:
+                        cursor = sys.maxsize
+                    else:
+                        cursor = (
+                            await session.exec(
+                                select(Score.pp)
+                                .where(*wheres)
+                                .order_by(col(Score.pp).desc())
+                                .offset((page - 1) * 50 - 1)
+                                .limit(1)
+                            )
+                        ).first()
+                        if cursor is None:
+                            break
+                    scores = (
                         await session.exec(
-                            select(Score.pp)
-                            .where(*wheres)
-                            .order_by(col(Score.pp).desc())
-                            .offset((page - 1) * 50 - 1)
-                            .limit(1)
+                            select(Score).where(*wheres, col(Score.pp) <= cursor).order_by(col(Score.pp).desc()).limit(50)
                         )
-                    ).first()
-                    if cursor is None:
-                        break
-                scores = (
-                    await session.exec(
-                        select(Score).where(*wheres, col(Score.pp) <= cursor).order_by(col(Score.pp).desc()).limit(50)
-                    )
-                ).all()
-                data = [
-                    await score.to_resp(
-                        session, api_version=NEW_SCORE_FORMAT_VER + 1, includes=ScoreModel.DEFAULT_SCORE_INCLUDES
-                    )
-                    for score in scores
+                    ).all()
+                    data = [
+                        await score.to_resp(
+                            session, api_version=NEW_SCORE_FORMAT_VER + 1, includes=ScoreModel.DEFAULT_SCORE_INCLUDES
+                        )
+                        for score in scores
+                    ]
+                    await self.cache_top_scores(data, ruleset, page)
+
+                    await asyncio.sleep(0.1)
+
+                logger.info(f"Completed top scores cache refresh for {ruleset}")
+
+            except Exception as e:
+                logger.error(f"Top scores cache refresh failed for {ruleset}: {e}")
+
+    async def refresh_mania_key_ranking_cache(
+        self,
+        session: AsyncSession,
+        key_count: int,
+        type: Literal["performance", "score"],
+        country: str | None = None,
+        max_pages: int | None = None,
+    ) -> None:
+        """Refresh mania key-specific ranking cache.
+
+        Args:
+            session: Database session.
+            key_count: The mania key count (e.g. 4, 7).
+            type: Ranking sort type.
+            country: Optional country code for country rankings.
+            max_pages: Maximum pages to cache.
+        """
+        country_part = f":{country}" if country else ""
+        lock_key = f"mania_key:{key_count}:{type}{country_part}"
+        lock = self._get_refresh_lock(lock_key)
+
+        # Skip if already refreshing this specific mania key ranking
+        if lock.locked():
+            logger.debug(f"Mania key ranking cache refresh already in progress for {key_count}K:{type}{country_part}")
+            return
+
+        async with lock:
+            if max_pages is None:
+                max_pages = settings.ranking_cache_max_pages
+
+            try:
+                logger.info(f"Starting mania key ranking cache refresh for {key_count}K:{type}{country_part}")
+
+                wheres = [
+                    col(ManiaKeyStatistics.key_count) == key_count,
+                    col(ManiaKeyStatistics.pp) > 0,
+                    col(ManiaKeyStatistics.is_ranked).is_(True),
                 ]
-                await self.cache_top_scores(data, ruleset, page)
+                include = ManiaKeyStatistics.RANKING_INCLUDES.copy()
 
-                await asyncio.sleep(0.1)
+                if type == "performance":
+                    order_by = col(ManiaKeyStatistics.pp).desc()
+                else:
+                    order_by = col(ManiaKeyStatistics.ranked_score).desc()
 
-            logger.info(f"Completed top scores cache refresh for {ruleset}")
+                if country:
+                    wheres.append(col(ManiaKeyStatistics.user).has(country_code=country.upper()))
+                    include.append("country_rank")
 
-        except Exception as e:
-            logger.error(f"Top scores cache refresh failed for {ruleset}: {e}")
-        finally:
-            self._refreshing = False
+                total_users_query = select(ManiaKeyStatistics).where(
+                    *wheres,
+                    ~User.is_restricted_query(col(ManiaKeyStatistics.user_id)),
+                )
+                total_users = len((await session.exec(total_users_query)).all())
+
+                stats = {
+                    "total": total_users,
+                    "total_users": total_users,
+                    "last_updated": utcnow().isoformat(),
+                    "type": type,
+                    "ruleset": f"mania_{key_count}",
+                    "country": country,
+                }
+
+                await self.cache_mania_key_stats(key_count, type, stats, country)
+
+                for page in range(1, max_pages + 1):
+                    try:
+                        statistics_list = await session.exec(
+                            select(ManiaKeyStatistics)
+                            .where(
+                                *wheres,
+                                ~User.is_restricted_query(col(ManiaKeyStatistics.user_id)),
+                            )
+                            .order_by(order_by)
+                            .limit(50)
+                            .offset(50 * (page - 1))
+                        )
+
+                        data = statistics_list.all()
+                        if not data:
+                            break
+
+                        ranking_data = []
+                        for stat in data:
+                            resp = await ManiaKeyStatisticsModel.transform(stat, includes=include)
+
+                            if settings.enable_asset_proxy:
+                                try:
+                                    resp = await replace_asset_urls(resp)
+                                except Exception as e:
+                                    logger.warning(f"Asset proxy processing failed for mania key ranking: {e}")
+
+                            ranking_data.append(resp)
+
+                        await self.cache_mania_key_ranking(key_count, type, ranking_data, country, page)
+
+                        if page < max_pages:
+                            await asyncio.sleep(0.1)
+
+                    except Exception as e:
+                        logger.error(f"Error caching mania key {key_count}K page {page} for {type}: {e}")
+
+                logger.info(f"Completed mania key ranking cache refresh for {key_count}K:{type}{country_part}")
+
+            except Exception as e:
+                logger.error(f"Mania key ranking cache refresh failed for {key_count}K:{type}{country_part}: {e}")
 
     async def refresh_all_rankings(self, session: AsyncSession) -> None:
         """Refresh all ranking caches."""
@@ -600,6 +827,12 @@ class RankingCacheService:
             task = self.refresh_top_scores_cache(session, mode)
             refresh_tasks.append(task)
 
+        # Mania key-specific rankings (for common key counts: 2K-10K)
+        for key_count in MANIA_COMMON_KEY_COUNTS:
+            for ranking_type in ranking_types:
+                task = self.refresh_mania_key_ranking_cache(session, key_count, ranking_type)
+                refresh_tasks.append(task)
+
         # Concurrent refresh with limited parallelism
         semaphore = asyncio.Semaphore(15)
 
@@ -635,6 +868,17 @@ class RankingCacheService:
                     await self.redis.delete(*keys)
                     deleted_keys += len(keys)
                     logger.info(f"Invalidated {len(keys)} cache keys for {ruleset}:{type}")
+
+                # Also invalidate mania key rankings when ruleset is mania
+                if ruleset.is_mania():
+                    mk_deleted = await self._invalidate_mania_key_pattern(
+                        f"mania_key_ranking:*:{type}{country_part}:page:*",
+                    )
+                    deleted_keys += mk_deleted
+                    mk_stats_deleted = await self._invalidate_mania_key_pattern(
+                        f"mania_key_ranking:stats:*:{type}{country_part}",
+                    )
+                    deleted_keys += mk_stats_deleted
             elif ruleset:
                 # Delete all caches for specific game mode
                 patterns = [
@@ -647,8 +891,13 @@ class RankingCacheService:
                         if keys:
                             await self.redis.delete(*keys)
                             deleted_keys += len(keys)
+
+                # Also invalidate all mania key rankings when ruleset is mania
+                if ruleset.is_mania():
+                    mk_deleted = await self._invalidate_mania_key_pattern("mania_key_ranking:*")
+                    deleted_keys += mk_deleted
             else:
-                # Delete all ranking caches
+                # Delete all ranking caches (including mania key rankings)
                 patterns = ["ranking:*"]
                 if include_country_ranking:
                     patterns.append("country_ranking:*")
@@ -659,10 +908,57 @@ class RankingCacheService:
                         await self.redis.delete(*keys)
                         deleted_keys += len(keys)
 
+                # Also delete all mania key ranking caches
+                mk_deleted = await self._invalidate_mania_key_pattern("mania_key_ranking:*")
+                deleted_keys += mk_deleted
+
                 logger.info(f"Invalidated all {deleted_keys} ranking cache keys")
 
         except Exception as e:
             logger.error(f"Error invalidating cache: {e}")
+
+    async def _invalidate_mania_key_pattern(self, pattern: str) -> int:
+        """Invalidate cache keys matching a mania key pattern.
+
+        Args:
+            pattern: Redis key glob pattern.
+
+        Returns:
+            Number of keys deleted.
+        """
+        keys = await self.redis.keys(pattern)
+        if keys:
+            await self.redis.delete(*keys)
+            logger.info(f"Invalidated {len(keys)} mania key cache keys matching '{pattern}'")
+            return len(keys)
+        return 0
+
+    async def invalidate_mania_key_cache(
+        self,
+        key_count: int | None = None,
+        type: Literal["performance", "score"] | None = None,
+    ) -> None:
+        """Invalidate mania key ranking caches.
+
+        Args:
+            key_count: Specific key count to invalidate. If None, invalidates all.
+            type: Specific ranking type to invalidate. If None, invalidates both.
+        """
+        try:
+            base = f"mania_key_ranking:{key_count}" if key_count is not None else "mania_key_ranking"
+
+            if type is not None:
+                patterns = [f"{base}:{type}:*", f"{base}:stats:{type}*"]
+            else:
+                patterns = [f"{base}:*"]
+
+            total_deleted = 0
+            for pattern in patterns:
+                total_deleted += await self._invalidate_mania_key_pattern(pattern)
+
+            logger.info(f"Invalidated {total_deleted} mania key ranking cache keys")
+        except Exception as e:
+            logger.error(f"Error invalidating mania key cache: {e}")
 
     async def invalidate_country_cache(self, ruleset: GameMode | None = None) -> None:
         """Invalidate country ranking cache."""
@@ -695,8 +991,10 @@ class RankingCacheService:
             ranking_keys = await self.redis.keys("ranking:*")
             # Get country ranking cache keys
             country_keys = await self.redis.keys("country_ranking:*")
+            # Get mania key ranking cache keys
+            mania_key_keys = await self.redis.keys("mania_key_ranking:*")
 
-            total_keys = ranking_keys + country_keys
+            total_keys = ranking_keys + country_keys + mania_key_keys
             total_size = 0
 
             for key in total_keys[:100]:  # Limit check count to avoid performance issues
@@ -711,9 +1009,10 @@ class RankingCacheService:
             return {
                 "cached_user_rankings": len(ranking_keys),
                 "cached_country_rankings": len(country_keys),
+                "cached_mania_key_rankings": len(mania_key_keys),
                 "total_cached_rankings": len(total_keys),
                 "estimated_total_size_mb": (round(total_size / 1024 / 1024, 2) if total_size > 0 else 0),
-                "refreshing": self._refreshing,
+                "refreshing": self.is_any_refreshing,
             }
         except Exception as e:
             logger.error(f"Error getting cache stats: {e}")

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -19,12 +19,13 @@ from .create_banchobot import create_banchobot
 from .daily_challenge import daily_challenge_job, process_daily_challenge_top
 from .geoip import init_geoip
 from .load_achievements import load_achievements
-from .special_statistics import create_custom_ruleset_statistics, create_rx_statistics
+from .special_statistics import create_custom_ruleset_statistics, create_mania_key_statistics, create_rx_statistics
 
 __all__ = [
     "calculate_user_rank",
     "create_banchobot",
     "create_custom_ruleset_statistics",
+    "create_mania_key_statistics",
     "create_rx_statistics",
     "daily_challenge_job",
     "init_geoip",

--- a/app/tasks/special_statistics.py
+++ b/app/tasks/special_statistics.py
@@ -165,8 +165,6 @@ async def create_mania_key_statistics() -> None:
 
         await session.commit()
         if created_count:
-            logger.success(
-                f"Created and recalculated {created_count} mania key statistics rows during backfill"
-            )
+            logger.success(f"Created and recalculated {created_count} mania key statistics rows during backfill")
         else:
             logger.info("All mania key statistics already exist, no backfill needed")

--- a/app/tasks/special_statistics.py
+++ b/app/tasks/special_statistics.py
@@ -1,18 +1,18 @@
 """Special statistics creation startup tasks.
 
 Provides backfill operations to create missing user statistics records
-for special game modes (Relax, Autopilot, custom rulesets).
+for special game modes (Relax, Autopilot, custom rulesets) and mania key counts.
 """
 
 from app.config import settings
-from app.const import BANCHOBOT_ID
+from app.const import BANCHOBOT_ID, MANIA_MAX_KEY_COUNT, MANIA_MIN_KEY_COUNT
 from app.database.statistics import UserStatistics
 from app.database.user import User
 from app.dependencies.database import with_db
 from app.log import logger
 from app.models.score import GameMode
 
-from sqlalchemy import exists
+from sqlalchemy import exists, func
 from sqlmodel import select
 
 
@@ -104,3 +104,69 @@ async def create_custom_ruleset_statistics() -> None:
         await session.commit()
         if created_count:
             logger.success(f"Created {created_count} custom ruleset statistics rows during backfill")
+
+
+async def create_mania_key_statistics() -> None:
+    """Create missing ManiaKeyStatistics records for existing mania players.
+
+    Finds all users who have mania scores and ensures they have
+    ManiaKeyStatistics records for each key count they've played.
+    Then recalculates the statistics from their existing scores.
+    """
+    from app.database.beatmap import Beatmap
+    from app.database.mania_key_statistics import ManiaKeyStatistics, recalculate_mania_key_statistics
+    from app.database.score import Score
+
+    async with with_db() as session:
+        # Find distinct (user_id, key_count) pairs from mania scores
+        result = await session.exec(
+            select(Score.user_id, func.floor(Beatmap.cs).label("key_count"))
+            .join(Beatmap, Score.beatmap_id == Beatmap.id)
+            .where(
+                Score.gamemode == GameMode.MANIA,
+                Score.passed == True,  # noqa: E712
+            )
+            .group_by(Score.user_id, func.floor(Beatmap.cs))
+        )
+        pairs = result.all()
+
+        if not pairs:
+            logger.info("No mania scores found, skipping mania key statistics backfill")
+            return
+
+        logger.info(f"Found {len(pairs)} user/key_count pairs for mania key statistics backfill")
+        created_count = 0
+        recalculated_count = 0
+
+        for user_id, key_count in pairs:
+            if user_id == BANCHOBOT_ID:
+                continue
+
+            key_count = int(key_count)
+            if key_count < MANIA_MIN_KEY_COUNT or key_count > MANIA_MAX_KEY_COUNT:
+                continue
+
+            # Check if ManiaKeyStatistics already exists
+            existing = (
+                await session.exec(
+                    select(ManiaKeyStatistics).where(
+                        ManiaKeyStatistics.user_id == user_id,
+                        ManiaKeyStatistics.key_count == key_count,
+                    )
+                )
+            ).first()
+
+            if existing is None:
+                # Create the record and recalculate from existing scores
+                await recalculate_mania_key_statistics(session, user_id, key_count, GameMode.MANIA)
+                created_count += 1
+            # Existing records are assumed to be correct; they get updated
+            # on new score submissions
+
+        await session.commit()
+        if created_count:
+            logger.success(
+                f"Created and recalculated {created_count} mania key statistics rows during backfill"
+            )
+        else:
+            logger.info("All mania key statistics already exist, no backfill needed")

--- a/main.py
+++ b/main.py
@@ -44,6 +44,7 @@ from app.tasks import (
     calculate_user_rank,
     create_banchobot,
     create_custom_ruleset_statistics,
+    create_mania_key_statistics,
     create_rx_statistics,
     daily_challenge_job,
     init_geoip,
@@ -89,6 +90,7 @@ async def lifespan(app: FastAPI):
     # init game server
     await create_rx_statistics()
     await create_custom_ruleset_statistics()
+    await create_mania_key_statistics()
     await calculate_user_rank(True)
     await daily_challenge_job()
     await process_daily_challenge_top()

--- a/migrations/versions/2026-04-26_a1b2c3d4e5f6_add_mania_key_statistics.py
+++ b/migrations/versions/2026-04-26_a1b2c3d4e5f6_add_mania_key_statistics.py
@@ -47,9 +47,18 @@ def upgrade() -> None:
         sa.Column("level_current", sa.Float(), nullable=False, server_default="1"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index(op.f("ix_lazer_user_mania_key_statistics_user_id"), "lazer_user_mania_key_statistics", ["user_id"], unique=False)
-    op.create_index(op.f("ix_lazer_user_mania_key_statistics_key_count"), "lazer_user_mania_key_statistics", ["key_count"], unique=False)
-    op.create_index(op.f("ix_lazer_user_mania_key_statistics_pp"), "lazer_user_mania_key_statistics", ["pp"], unique=False)
+    op.create_index(
+        op.f("ix_lazer_user_mania_key_statistics_user_id"), "lazer_user_mania_key_statistics", ["user_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_lazer_user_mania_key_statistics_key_count"),
+        "lazer_user_mania_key_statistics",
+        ["key_count"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_lazer_user_mania_key_statistics_pp"), "lazer_user_mania_key_statistics", ["pp"], unique=False
+    )
     op.create_index(
         "ix_mania_key_stats_user_key",
         "lazer_user_mania_key_statistics",

--- a/migrations/versions/2026-04-26_a1b2c3d4e5f6_add_mania_key_statistics.py
+++ b/migrations/versions/2026-04-26_a1b2c3d4e5f6_add_mania_key_statistics.py
@@ -1,0 +1,132 @@
+"""add mania key statistics table and key_count to rank history
+
+Revision ID: a1b2c3d4e5f6
+Revises: 5e5f052d0fe2
+Create Date: 2026-04-26 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = "5e5f052d0fe2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create mania key statistics table and add key_count to rank_history/rank_top."""
+    # Create the lazer_user_mania_key_statistics table
+    op.create_table(
+        "lazer_user_mania_key_statistics",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), sa.ForeignKey("lazer_users.id"), nullable=False),
+        sa.Column("key_count", sa.Integer(), nullable=False),
+        sa.Column("count_100", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("count_300", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("count_50", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("count_miss", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("pp", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("ranked_score", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("hit_accuracy", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("total_score", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("total_hits", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("maximum_combo", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("play_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("play_time", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("is_ranked", sa.Boolean(), nullable=False, server_default="1"),
+        sa.Column("grade_ss", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("grade_ssh", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("grade_s", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("grade_sh", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("grade_a", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("level_current", sa.Float(), nullable=False, server_default="1"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_lazer_user_mania_key_statistics_user_id"), "lazer_user_mania_key_statistics", ["user_id"], unique=False)
+    op.create_index(op.f("ix_lazer_user_mania_key_statistics_key_count"), "lazer_user_mania_key_statistics", ["key_count"], unique=False)
+    op.create_index(op.f("ix_lazer_user_mania_key_statistics_pp"), "lazer_user_mania_key_statistics", ["pp"], unique=False)
+    op.create_index(
+        "ix_mania_key_stats_user_key",
+        "lazer_user_mania_key_statistics",
+        ["user_id", "key_count"],
+        unique=True,
+    )
+
+    # Add key_count column to rank_history
+    op.add_column(
+        "rank_history",
+        sa.Column("key_count", sa.Integer(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_rank_history_key_count"),
+        "rank_history",
+        ["key_count"],
+    )
+
+    # Add key_count column to rank_top
+    op.add_column(
+        "rank_top",
+        sa.Column("key_count", sa.Integer(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_rank_top_key_count"),
+        "rank_top",
+        ["key_count"],
+    )
+
+    # Migrate existing mania key mode data from "mania_X" format
+    # to proper GameMode.MANIA + key_count columns
+    # e.g. mode="mania_4" -> mode="mania", key_count=4
+    op.execute(
+        """
+        UPDATE rank_history
+        SET mode = 'mania', key_count = CAST(SUBSTRING(mode, 7) AS UNSIGNED)
+        WHERE mode LIKE 'mania_%' AND mode != 'mania'
+        """
+    )
+    op.execute(
+        """
+        UPDATE rank_top
+        SET mode = 'mania', key_count = CAST(SUBSTRING(mode, 7) AS UNSIGNED)
+        WHERE mode LIKE 'mania_%' AND mode != 'mania'
+        """
+    )
+
+
+def downgrade() -> None:
+    """Remove mania key statistics table and key_count columns."""
+    # Revert mania key data back to "mania_X" format
+    op.execute(
+        """
+        UPDATE rank_history
+        SET mode = CONCAT('mania_', key_count)
+        WHERE mode = 'mania' AND key_count IS NOT NULL
+        """
+    )
+    op.execute(
+        """
+        UPDATE rank_top
+        SET mode = CONCAT('mania_', key_count)
+        WHERE mode = 'mania' AND key_count IS NOT NULL
+        """
+    )
+
+    # Remove key_count from rank_top
+    op.drop_index(op.f("ix_rank_top_key_count"), table_name="rank_top")
+    op.drop_column("rank_top", "key_count")
+
+    # Remove key_count from rank_history
+    op.drop_index(op.f("ix_rank_history_key_count"), table_name="rank_history")
+    op.drop_column("rank_history", "key_count")
+
+    # Drop the mania key statistics table
+    op.drop_index("ix_mania_key_stats_user_key", table_name="lazer_user_mania_key_statistics")
+    op.drop_index(op.f("ix_lazer_user_mania_key_statistics_pp"), table_name="lazer_user_mania_key_statistics")
+    op.drop_index(op.f("ix_lazer_user_mania_key_statistics_key_count"), table_name="lazer_user_mania_key_statistics")
+    op.drop_index(op.f("ix_lazer_user_mania_key_statistics_user_id"), table_name="lazer_user_mania_key_statistics")
+    op.drop_table("lazer_user_mania_key_statistics")

--- a/tools/recalculate.py
+++ b/tools/recalculate.py
@@ -17,10 +17,11 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from app.calculating import CalculateError, calculate_pp, calculate_score_to_level, init_calculator
 from app.config import settings
-from app.const import BANCHOBOT_ID
+from app.const import BANCHOBOT_ID, MANIA_MAX_KEY_COUNT, MANIA_MIN_KEY_COUNT
 from app.database import TotalScoreBestScore, UserStatistics
 from app.database.beatmap import Beatmap, calculate_beatmap_attributes, clear_cached_beatmap_raws
 from app.database.best_scores import BestScore
+from app.database.mania_key_statistics import recalculate_mania_key_statistics
 from app.database.score import Score, calculate_playtime, calculate_user_pp
 from app.dependencies.database import engine, get_redis
 from app.dependencies.fetcher import get_fetcher
@@ -746,6 +747,31 @@ def build_total_score_best_scores(scores: list[Score]) -> list[TotalScoreBestSco
     return result
 
 
+async def _recalculate_mania_key_stats(
+    session: AsyncSession,
+    user_id: int,
+    gamemode: GameMode,
+    scores: list[Score],
+) -> None:
+    """Recalculate all mania key statistics for a user in a given mode.
+
+    Finds all distinct key counts from the user's scores and recalculates
+    each key count's statistics from scratch.
+    """
+    # Collect distinct key counts from beatmap CS values
+    key_counts: set[int] = set()
+    for score in scores:
+        beatmap = score.beatmap
+        if beatmap is not None:
+            kc = int(beatmap.cs)
+            if MANIA_MIN_KEY_COUNT <= kc <= MANIA_MAX_KEY_COUNT:
+                key_counts.add(kc)
+
+    for key_count in sorted(key_counts):
+        await recalculate_mania_key_statistics(session, user_id, key_count, gamemode)
+        logger.debug(f"Recalculated mania key statistics for user {user_id} key_count={key_count}")
+
+
 async def _recalculate_statistics(
     statistics: UserStatistics,
     session: AsyncSession,
@@ -896,6 +922,10 @@ async def recalculate_user_mode_performance(
             await _recalculate_statistics(statistics, session, scores)
             await session.flush()
 
+            # Recalculate mania key statistics if this is a mania mode
+            if gamemode.is_mania():
+                await _recalculate_mania_key_stats(session, user_id, gamemode, scores)
+
             new_pp = float(statistics.pp or 0)
             new_acc = float(statistics.hit_accuracy or 0)
 
@@ -1009,6 +1039,11 @@ async def recalculate_user_mode_leaderboard(
             # Recalculate statistics using the helper function
             await _recalculate_statistics(statistics, session, scores)
             await session.flush()
+
+            # Recalculate mania key statistics if this is a mania mode
+            if gamemode.is_mania():
+                await _recalculate_mania_key_stats(session, user_id, gamemode, scores)
+
             changes = {
                 "ranked_score": statistics.ranked_score - previous_data["ranked_score"],
                 "maximum_combo": statistics.maximum_combo - previous_data["maximum_combo"],


### PR DESCRIPTION
实现一个完整的 mania 按键数（4K / 7K 等）统计系统，
允许用户根据谱面 Circle Size（CS）对应的不同键位配置，
分别记录和查看独立的表现数据。

数据库变更：
新增 lazer_user_mania_key_statistics 表，包含完整统计字段
在 RankHistory 和 RankTop 表中新增 key_count 字段

核心功能：
在提交成绩时进行增量更新，并按 key_count 独立维护最佳成绩
删除成绩时执行全量重算以保证数据一致性
支持基于 key_count 过滤的 PP 计算
为现有用户提供启动时的历史数据回填任务

API 接口：
GET /api/private/rankings/mania/{key_count}/{sort} GET /api/private/rankings/mania/user/{user_id}

缓存基础设施：
完整的 Redis 缓存层，并为每个 key 使用 asyncio.Lock（修复竞态条件）
周期性刷新机制已集成到现有排行榜缓存更新流程中